### PR TITLE
Fixing volatile type

### DIFF
--- a/dht.cpp
+++ b/dht.cpp
@@ -176,7 +176,7 @@ int8_t dht::_readSensor(uint8_t pin, uint8_t wakeupDelay, uint8_t leadingZeroBit
     // direct port read is about 3x faster
     uint8_t bit = digitalPinToBitMask(pin);
     uint8_t port = digitalPinToPort(pin);
-    volatile uint8_t *PIR = portInputRegister(port);
+    volatile uint32_t *PIR = portInputRegister(port);
 
     // REQUEST SAMPLE
     pinMode(pin, OUTPUT);


### PR DESCRIPTION
volatile type uint8_t is not compatible with `Arduino.h` which is uint32_t

Build output error:
```
WARNING: library DHTlib claims to run on avr architecture(s) and may be incompatible with your current board which runs on esp8266 architecture(s).
In file included from /home/st/Arduino/libraries/DHTlib/dht.h:20,
                 from /home/st/Arduino/libraries/DHTlib/dht.cpp:51:
/home/st/Arduino/libraries/DHTlib/dht.cpp: In member function 'int8_t dht::_readSensor(uint8_t, uint8_t, uint8_t)':
/home/st/.arduino15/packages/esp8266/hardware/esp8266/3.0.2/cores/esp8266/Arduino.h:202:60: error: cannot convert 'volatile uint32_t*' {aka 'volatile unsigned int*'} to 'volatile uint8_t*' {aka 'volatile unsigned char*'} in initialization
  202 | #define portInputRegister(port)     (((port)==_PORT_GPIO16)?((volatile uint32_t*) &GP16I):((volatile uint32_t*) &GPI))
      |                                     ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                            |
      |                                                            volatile uint32_t* {aka volatile unsigned int*}
/home/st/Arduino/libraries/DHTlib/dht.cpp:179:29: note: in expansion of macro 'portInputRegister'
  179 |     volatile uint8_t *PIR = portInputRegister(port);
      |                             ^~~~~~~~~~~~~~~~~
Error during build: exit status 1
```